### PR TITLE
Fix GitHub Action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,7 @@ jobs:
           key: ${{ runner.os }}-gnat-2020.1
           restore-keys: ${{ runner.os }}-gnat-2020.1
       - name: Get GNAT Community 2020 toolchain
-        uses: ada-actions/toolchain@52618bd
+        uses: ada-actions/toolchain@ce2020
         with:
           distrib: community
           install_dir: ./cached_gnat

--- a/source/text/implementation/vss-implementation-string_handlers.adb
+++ b/source/text/implementation/vss-implementation-string_handlers.adb
@@ -227,9 +227,9 @@ package body VSS.Implementation.String_Handlers is
           or not Left_Handler.Has_Character (Left_Data, Left_Position);
    end Is_Less_Or_Equal;
 
-   -----------------
-   -- Slow_Append --
-   -----------------
+   ------------
+   -- Append --
+   ------------
 
    procedure Append
      (Self           : Abstract_String_Handler;


### PR DESCRIPTION
Looks like the shortened version of a commit SHA is
not supported as a action reference. Replace it with
the branch name.