### PR TITLE
Replace Build_Kind with Project_Build_Kind

### DIFF
--- a/gnat/vss_config.gpr
+++ b/gnat/vss_config.gpr
@@ -24,8 +24,8 @@
 
 abstract project VSS_Config is
 
-   type Build_Kind is ("dev", "prod", "coverage");
-   Build_Mode : Build_Kind :=
+   type VSS_Build_Kind is ("dev", "prod", "coverage");
+   Build_Mode : VSS_Build_Kind :=
      external ("VSS_BUILD_MODE", external ("BUILD_MODE", "prod"));
 
    Ada_Switches := ();


### PR DESCRIPTION
to avoid name clash with gprinstall generated code.