### PR TITLE
Improve RegExp parser and engine

### DIFF
--- a/source/regexp/implementation/vss-regular_expressions-ecma_parser.ads
+++ b/source/regexp/implementation/vss-regular_expressions-ecma_parser.ads
@@ -33,6 +33,9 @@ generic
    with function Create_Character (Value : VSS.Characters.Virtual_Character)
      return Node is <>;
 
+   with function Create_Character_Range
+     (From, To : VSS.Characters.Virtual_Character) return Node is <>;
+
    with function Create_Sequence (Left, Right : Node) return Node is <>;
    with function Create_Alternative (Left, Right : Node) return Node is <>;
    with function Create_Star (Left : Node) return Node is <>;

--- a/source/regexp/implementation/vss-regular_expressions-pike_engines.ads
+++ b/source/regexp/implementation/vss-regular_expressions-pike_engines.ads
@@ -49,6 +49,7 @@ private
      (No_Operation,  --  To able accept an empty string
       Split,         --  Create an alternative thread of execution
       Character,     --  Accept one Virtual_Character
+      Class,         --  Accept one Virtual_Character from a class
       Match,         --  Mark accepted string prefix as a regexp match
       Save);         --  Save subgroup bound
    --  VM instruction kinds
@@ -62,6 +63,8 @@ private
             Fallback : Instruction_Address;
          when Character =>
             Character : VSS.Characters.Virtual_Character;
+         when Class =>
+            From, To : VSS.Characters.Virtual_Character;
          when Save =>
             Tag : Tag_Number;
          when No_Operation | Match =>


### PR DESCRIPTION
by enabling a character class ranges in form of `[a-z]`.
Introduce some diagostic messages on parsing errors.