### PR TITLE
Drop `'Class` from Hash function

### DIFF
--- a/source/text/implementation/vss-strings-hash.adb
+++ b/source/text/implementation/vss-strings-hash.adb
@@ -22,7 +22,7 @@
 ------------------------------------------------------------------------------
 
 function VSS.Strings.Hash
-  (Self : VSS.Strings.Virtual_String'Class)
+  (Self : VSS.Strings.Virtual_String)
     return Ada.Containers.Hash_Type is
 begin
    return Ada.Containers.Hash_Type'Mod (VSS.Strings.Hash_Type'(Self.Hash));

--- a/source/text/vss-strings-hash.ads
+++ b/source/text/vss-strings-hash.ads
@@ -24,5 +24,5 @@
 with Ada.Containers;
 
 function VSS.Strings.Hash
-  (Self : VSS.Strings.Virtual_String'Class)
+  (Self : VSS.Strings.Virtual_String)
    return Ada.Containers.Hash_Type;


### PR DESCRIPTION
to match expected profile in Ada.Containers.Hash_Sets/Maps.