### PR TITLE
RegExp: Implement `^`, `$`, `\b`, `\B` assertions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 alire
-alire.lock
+.libs
 .objs
 re_tests

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ GPRINSTALL_FLAGS = --prefix=$(PREFIX) --exec-subdir=$(INSTALL_EXEC_DIR)\
  --lib-subdir=$(INSTALL_ALI_DIR) --project-subdir=$(INSTALL_PROJECT_DIR)\
  --link-lib-subdir=$(INSTALL_LIBRARY_DIR) --sources-subdir=$(INSTALL_INCLUDE_DIR)
 
-OK_RE_TESTS := 404 # Number of re_tests to be passed
+OK_RE_TESTS := 445 # Number of re_tests to be passed
 
 ifeq ($(OS),Windows_NT)
 	VSS_PS=;

--- a/source/regexp/README.md
+++ b/source/regexp/README.md
@@ -1,0 +1,32 @@
+# RegExp engine
+
+This regexp engine should implement
+[ECMAScript Regular Expression](https://tc39.es/ecma262/#sec-regexp-regular-expression-objects)
+(Unicode Mode), but currently only part of specification is implemented.
+
+For now we have:
+
+|  RegExp                   | Description                               |
+| ------------------------- | ----------------------------------------- |
+| *x* *y*                   | Match the *x* then *y*                    |
+| *x* **\|** *y*            | Match either the *x* or *y*               |
+| *x* **\***                | Match the *x* zero or more times          |
+| **(:?** *x* **)**         | Non-capturing group                       |
+| **(** *x* **)**           | Capturing group                           |
+| **\p{** *N* **}**         | Char of the general category *N*          |
+| **\P{** *N* **}**         | Char not of the general category *N*      |
+| **[** *x* **]**           | Character class *x*                       |
+| **[^** *x* **]**          | Character not in the class *x*            |
+| **[** *x* **-** *y* **]** | Character in range *x..y*                 |
+| **[\p{** *N* **}]**       | Char of the general category *N*          |
+| **[\P{** *N* **}]**       | Char not of the general category *N*      |
+|  **^**                    | Start of line assertion                   |
+|  **$**                    | End of line assertion                     |
+|  **\b**                   | Word boundary assertion                   |
+|  **\B**                   | Not a word boundary assertion             |
+|  *x*                      | Character literal *x*, not in `^$.*+?]{}` |
+|  **\\** *x*               | Character literal *x* in `^$.*+?]{}`      |
+
+## Useful articles
+
+* https://tc39.es/ecma262

--- a/source/regexp/implementation/vss-regular_expressions-ecma_parser.adb
+++ b/source/regexp/implementation/vss-regular_expressions-ecma_parser.adb
@@ -68,7 +68,10 @@ package body VSS.Regular_Expressions.ECMA_Parser is
       procedure Term (Value : out Node_Or_Class; Ok : in out Boolean)
         with Pre => Ok;
 
-      procedure Atom (Value : out Node_Or_Class; Ok : in out Boolean)
+      procedure Atom_Or_Assertion
+        (Value   : out Node_Or_Class;
+         Is_Atom : out Boolean;
+         Ok      : in out Boolean)
         with Pre => Ok;
 
       procedure Atom_Escape (Value : out Node_Or_Class; Ok : in out Boolean)
@@ -153,8 +156,23 @@ package body VSS.Regular_Expressions.ECMA_Parser is
          end if;
       end Alternative;
 
-      procedure Atom (Value : out Node_Or_Class; Ok : in out Boolean) is
+      procedure Atom_Escape (Value : out Node_Or_Class; Ok : in out Boolean) is
+         Set : Name_Sets.General_Category_Set;
       begin
+         Character_Class_Escape (Set, Ok);
+
+         if Ok then
+            Value := (Has_Node => False, Category => Set);
+         end if;
+      end Atom_Escape;
+
+      procedure Atom_Or_Assertion
+        (Value   : out Node_Or_Class;
+         Is_Atom : out Boolean;
+         Ok      : in out Boolean) is
+      begin
+         Is_Atom := True;
+
          if not Cursor.Has_Element then
             if Error.Is_Empty then
                Error := "Unexpected end of string while atom expected.";
@@ -192,7 +210,18 @@ package body VSS.Regular_Expressions.ECMA_Parser is
 
             when '\' =>
                Expect ('\', Ok);
-               Atom_Escape (Value, Ok);
+
+               if Cursor.Has_Element and then Cursor.Element in 'b' | 'B' then
+                  Value := From_Node
+                    (Create_Simple_Assertion
+                      (if Cursor.Element = 'b' then Word_Boundary
+                       else No_Word_Boundary));
+
+                  Expect (Cursor.Element, Ok);
+
+               else
+                  Atom_Escape (Value, Ok);
+               end if;
 
             when '^' | '$' | '.' | '*' | '+' | '?' | ']' | '{' | '}' =>
                if Error.Is_Empty then
@@ -206,17 +235,7 @@ package body VSS.Regular_Expressions.ECMA_Parser is
                Value := From_Node (Create_Character (Cursor.Element));
                Expect (Cursor.Element, Ok);
          end case;
-      end Atom;
-
-      procedure Atom_Escape (Value : out Node_Or_Class; Ok : in out Boolean) is
-         Set : Name_Sets.General_Category_Set;
-      begin
-         Character_Class_Escape (Set, Ok);
-
-         if Ok then
-            Value := (Has_Node => False, Category => Set);
-         end if;
-      end Atom_Escape;
+      end Atom_Or_Assertion;
 
       procedure Character_Class
         (Value : out Node_Or_Class; Ok : in out Boolean)
@@ -468,12 +487,26 @@ package body VSS.Regular_Expressions.ECMA_Parser is
       end Lone_Unicode_Property_Name_Or_Value;
 
       procedure Term (Value : out Node_Or_Class; Ok : in out Boolean) is
+         Is_Atom : Boolean := False;
       begin
-         Atom (Value, Ok);
+         if Cursor.Has_Element and then Cursor.Element in '^' | '$' then
+            Value := From_Node
+              (Create_Simple_Assertion
+                (if Cursor.Element = '^' then Start_Of_Line else End_Of_Line));
+
+            Expect (Cursor.Element, Ok);
+         else
+            Atom_Or_Assertion (Value, Is_Atom, Ok);
+         end if;
 
          if Ok and then Cursor.Has_Element and then Cursor.Element = '*' then
-            Expect (Cursor.Element, Ok);
-            Value := From_Node (Create_Star (To_Node (Value)));
+            if Is_Atom then
+               Expect (Cursor.Element, Ok);
+               Value := From_Node (Create_Star (To_Node (Value)));
+            else
+               Ok := False;
+               Error := "The assertion is not quantifiable";
+            end if;
          end if;
       end Term;
 

--- a/source/regexp/implementation/vss-regular_expressions-ecma_parser.ads
+++ b/source/regexp/implementation/vss-regular_expressions-ecma_parser.ads
@@ -12,7 +12,7 @@ with VSS.Characters;
 with VSS.Strings.Character_Iterators;
 with VSS.Regular_Expressions.Name_Sets;
 
-generic
+private generic
    type Node is private;
 
    with function Create_Character (Value : VSS.Characters.Virtual_Character)
@@ -23,6 +23,9 @@ generic
 
    with function Create_General_Category_Set
      (Value : Name_Sets.General_Category_Set) return Node is <>;
+
+   with function Create_Simple_Assertion (Kind : Simple_Assertion_Kind)
+     return Node is <>;
 
    with function Create_Sequence (Left, Right : Node) return Node is <>;
    with function Create_Alternative (Left, Right : Node) return Node is <>;

--- a/source/regexp/implementation/vss-regular_expressions-pike_engines.adb
+++ b/source/regexp/implementation/vss-regular_expressions-pike_engines.adb
@@ -58,18 +58,25 @@ package body VSS.Regular_Expressions.Pike_Engines is
       --  Shift Cursor one character backward in string Text
 
       procedure Append_State
-        (Cursor   : VSS.Implementation.Strings.Cursor;
+        (Cursor   : VSS.Strings.Character_Iterators.Character_Iterator;
+         Prev     : VSS.Characters.Virtual_Character;
          PC       : Instruction_Address;
          New_Tags : Tag_Array);
-      --  This procedure finds all states reachable from the given by
+      --  This procedure finds all states reachable from the given PC by
       --  non-character instructions and appends new thread states to the
-      --  Next global variable.
+      --  Next global variable. Cursor points to a next unprocessed character
+      --  if any. Prev is a previous character if Cursor isn't the first
+      --  character of the subject.
 
       function Character_In_Class
         (PC   : Instruction_Address;
          Char : VSS.Characters.Virtual_Character) return Boolean;
       --  Check if Char in the class defined by a program started from PC.
       --  Program should contain only Split and character instructions.
+
+      procedure Loop_Over_Characters
+        (Cursor : in out VSS.Strings.Character_Iterators.Character_Iterator);
+      --  Iterate over all characters of the Subject using Cursor
 
       package State_Vectors is new Ada.Containers.Vectors
         (Positive, Thread_State);
@@ -95,35 +102,82 @@ package body VSS.Regular_Expressions.Pike_Engines is
       ------------------
 
       procedure Append_State
-        (Cursor   : VSS.Implementation.Strings.Cursor;
+        (Cursor   : VSS.Strings.Character_Iterators.Character_Iterator;
+         Prev     : VSS.Characters.Virtual_Character;
          PC       : Instruction_Address;
          New_Tags : Tag_Array)
       is
+         function Is_Valid_Assertion (Kind : Simple_Assertion_Kind)
+           return Boolean;
+         --  Check given assertion
+
+         function Is_Word_Char (Char : VSS.Characters.Virtual_Character)
+           return Boolean is (Char in 'A' .. 'Z' | 'a' .. 'z' | '_');
+
+         ------------------------
+         -- Is_Valid_Assertion --
+         ------------------------
+
+         function Is_Valid_Assertion (Kind : Simple_Assertion_Kind)
+           return Boolean
+         is
+            use type VSS.Strings.Character_Index;
+         begin
+            case Kind is
+               when Start_Of_Line =>
+                  return Cursor.Character_Index = 1;
+               when End_Of_Line =>
+                  return not Cursor.Has_Element;
+               when Word_Boundary =>
+                  return (Cursor.Character_Index > 1 and then
+                           Is_Word_Char (Prev))
+                    xor (Cursor.Has_Element and then
+                           Is_Word_Char (Cursor.Element));
+               when No_Word_Boundary =>
+                  return not Is_Valid_Assertion (Word_Boundary);
+            end case;
+         end Is_Valid_Assertion;
+
          Code : constant Instruction := Self.Program (PC);
+         Next : constant Instruction_Address := PC + Code.Next;
+
       begin
          if Steps (PC) = Step then
-            return;
+            return;  --  Skip already processed PC
          end if;
 
          Steps (PC) := Step;
 
          case Code.Kind is
             when Character | Class | Category | Negate_Class | Match =>
-               Next.Append ((PC, New_Tags));
+               Match.Next.Append ((PC, New_Tags));
             when Split =>
-               Append_State (Cursor, PC + Code.Next, New_Tags);
-               Append_State (Cursor, PC + Code.Fallback, New_Tags);
+               Append_State (Cursor, Prev, Next, New_Tags);
+               Append_State (Cursor, Prev, PC + Code.Fallback, New_Tags);
             when Save =>
                declare
                   Updated : Tag_Array := New_Tags;
+
+                  Pos : constant not null
+                    VSS.Strings.Cursors.Internals.Cursor_Constant_Access :=
+                     VSS.Strings.Cursors.Internals.First_Cursor_Access_Constant
+                       (Cursor);
                begin
-                  Updated (Code.Tag) := Cursor;
-                  Append_State (Cursor, PC + Code.Next, Updated);
+                  Updated (Code.Tag) := Pos.all;
+                  Append_State (Cursor, Prev, Next, Updated);
                end;
+            when Assertion =>
+               if Is_Valid_Assertion (Code.Assertion) then
+                  Append_State (Cursor, Prev, Next, New_Tags);
+               end if;
             when No_Operation =>
-               Append_State (Cursor, PC + Code.Next, New_Tags);
+               Append_State (Cursor, Prev, Next, New_Tags);
          end case;
       end Append_State;
+
+      ------------------------
+      -- Character_In_Class --
+      ------------------------
 
       function Character_In_Class
         (PC   : Instruction_Address;
@@ -152,57 +206,19 @@ package body VSS.Regular_Expressions.Pike_Engines is
          end case;
       end Character_In_Class;
 
-      -------------------
-      -- Step_Backward --
-      -------------------
+      --------------------------
+      -- Loop_Over_Characters --
+      --------------------------
 
-      procedure Step_Backward
-        (Text   : VSS.Strings.Virtual_String'Class;
-         Cursor : in out VSS.Implementation.Strings.Cursor)
-      is
-         use type VSS.Unicode.UTF8_Code_Unit_Offset;
-         use type VSS.Unicode.UTF16_Code_Unit_Offset;
-         use type VSS.Implementation.Strings.String_Handler_Access;
-
-         Ignore : Boolean;
-         Data   : constant VSS.Strings.Internals.String_Data_Constant_Access :=
-           VSS.Strings.Internals.Data_Access_Constant (Text);
-
-         Handler : constant VSS.Implementation.Strings.String_Handler_Access :=
-           VSS.Implementation.Strings.Handler (Data.all);
+      procedure Loop_Over_Characters
+        (Cursor : in out VSS.Strings.Character_Iterators.Character_Iterator) is
       begin
-         if VSS.Implementation.Strings.Is_Invalid (Cursor) then
-            null;
-         elsif Handler = null then
-            Cursor := (0, -1, -1);
-         else
-            Ignore := Handler.Backward (Data.all, Cursor);
-         end if;
-      end Step_Backward;
-
-      use type VSS.Strings.Character_Count;
-
-      Cursor : VSS.Strings.Character_Iterators.Character_Iterator :=
-        Subject.At_First_Character;
-
-      Pos : constant not null
-        VSS.Strings.Cursors.Internals.Cursor_Constant_Access :=
-          VSS.Strings.Cursors.Internals.First_Cursor_Access_Constant (Cursor);
-      --  Access to position of the Cursor
-   begin
-      Active.Reserve_Capacity (Ada.Containers.Count_Type (Self.Max_Threads));
-      Next.Reserve_Capacity (Ada.Containers.Count_Type (Self.Max_Threads));
-
-      --  Start a new thread at the beginning of the sample
-      Append_State (Pos.all, 1, Unset_Tags);
-
-      if Cursor.Has_Element then
          loop
             declare
                Char : constant VSS.Characters.Virtual_Character :=
                  Cursor.Element;
 
-               --  Shift Cursor, Pos points to the next character after Char
+               --  Shift Cursor, so it points to the next character after Char
                Again : constant Boolean := Cursor.Forward;
             begin
                Active.Move (Source => Next);  --  Assign Next to Active
@@ -212,16 +228,17 @@ package body VSS.Regular_Expressions.Pike_Engines is
                for X of Active loop
                   declare
                      Code : constant Instruction := Self.Program (X.PC);
+                     Next : constant Instruction_Address := X.PC + Code.Next;
                   begin
                      case Code.Kind is
                         when Character =>
                            if Code.Character = Char then
-                              Append_State (Pos.all, X.PC + Code.Next, X.Tags);
+                              Append_State (Cursor, Char, Next, X.Tags);
                            end if;
 
                         when Class =>
                            if Char in Code.From .. Code.To then
-                              Append_State (Pos.all, X.PC + Code.Next, X.Tags);
+                              Append_State (Cursor, Char, Next, X.Tags);
                            end if;
 
                         when Category =>
@@ -229,12 +246,12 @@ package body VSS.Regular_Expressions.Pike_Engines is
                                (Code.Category,
                                 VSS.Characters.Get_General_Category (Char))
                            then
-                              Append_State (Pos.all, X.PC + Code.Next, X.Tags);
+                              Append_State (Cursor, Char, Next, X.Tags);
                            end if;
 
                         when Negate_Class =>
                            if not Character_In_Class (X.PC + 1, Char) then
-                              Append_State (Pos.all, X.PC + Code.Next, X.Tags);
+                              Append_State (Cursor, Char, Next, X.Tags);
                            end if;
 
                         when Match =>
@@ -253,10 +270,53 @@ package body VSS.Regular_Expressions.Pike_Engines is
                if not Found and not Options (Anchored_Match) then
                   --  Start new thread from the current character if we haven't
                   --  found any match yet nor we are in anchored match.
-                  Append_State (Pos.all, 1, Unset_Tags);
+                  Append_State (Cursor, Char, 1, Unset_Tags);
                end if;
             end;
          end loop;
+      end Loop_Over_Characters;
+
+      -------------------
+      -- Step_Backward --
+      -------------------
+
+      procedure Step_Backward
+        (Text   : VSS.Strings.Virtual_String'Class;
+         Cursor : in out VSS.Implementation.Strings.Cursor)
+      is
+         use type VSS.Implementation.Strings.String_Handler_Access;
+
+         Ignore : Boolean;
+
+         Data   : constant VSS.Strings.Internals.String_Data_Constant_Access :=
+           VSS.Strings.Internals.Data_Access_Constant (Text);
+
+         Handler : constant VSS.Implementation.Strings.String_Handler_Access :=
+           VSS.Implementation.Strings.Handler (Data.all);
+      begin
+         if VSS.Implementation.Strings.Is_Invalid (Cursor) then
+            null;
+         elsif Handler = null then
+            Cursor := (others => <>);  --  Make it invalid
+         else
+            Ignore := Handler.Backward (Data.all, Cursor);
+         end if;
+      end Step_Backward;
+
+      use type VSS.Strings.Character_Count;
+
+      Cursor : VSS.Strings.Character_Iterators.Character_Iterator :=
+        Subject.At_First_Character;
+
+   begin
+      Active.Reserve_Capacity (Ada.Containers.Count_Type (Self.Max_Threads));
+      Next.Reserve_Capacity (Ada.Containers.Count_Type (Self.Max_Threads));
+
+      --  Start a new thread at the beginning of the sample
+      Append_State (Cursor, ' ', 1, Unset_Tags);
+
+      if Cursor.Has_Element then
+         Loop_Over_Characters (Cursor);
       end if;
 
       Active.Move (Source => Next);
@@ -377,6 +437,10 @@ package body VSS.Regular_Expressions.Pike_Engines is
       function Create_Character_Range
         (From, To : VSS.Characters.Virtual_Character) return Node;
       --  Generate <class[from,to,next:unlinked]>
+
+      function Create_Simple_Assertion
+        (Kind : Simple_Assertion_Kind) return Node;
+      --  Generate <assertion[kind,next:unlinked]>
 
       function Create_General_Category_Set
         (Value : Name_Sets.General_Category_Set) return Node;
@@ -569,6 +633,23 @@ package body VSS.Regular_Expressions.Pike_Engines is
             end loop;
          end return;
       end Create_Sequence;
+
+      -----------------------------
+      -- Create_Simple_Assertion --
+      -----------------------------
+
+      function Create_Simple_Assertion
+        (Kind : Simple_Assertion_Kind) return Node
+      is
+         Code : constant Instruction :=
+           (Kind      => Assertion,
+            Next      => To_Be_Patched,
+            Assertion => Kind);
+      begin
+         return
+           (Program => Instruction_Vectors.To_Vector (Code, Length => 1),
+            Ends    => First_Instruction);
+      end Create_Simple_Assertion;
 
       -----------------
       -- Create_Star --

--- a/source/regexp/implementation/vss-regular_expressions-pike_engines.ads
+++ b/source/regexp/implementation/vss-regular_expressions-pike_engines.ads
@@ -37,6 +37,7 @@ private
       Class,         --  Accept one Virtual_Character from a range
       Category,      --  Accept one Virtual_Character from a general category
       Negate_Class,  --  Accept one Virtual_Character if not in a class/range
+      Assertion,     --  Accept one assertion, like ^, $, \b, \B
       Match,         --  Mark accepted string prefix as a regexp match
       Save);         --  Save subgroup bound
    --  VM instruction kinds
@@ -58,6 +59,8 @@ private
             --  Program to define char class starts from the next
             --  instruction after Negate_Class
             null;
+         when Assertion =>
+            Assertion : Simple_Assertion_Kind;
          when Save =>
             Tag : Tag_Number;
          when No_Operation | Match =>

--- a/source/regexp/vss-regular_expressions.ads
+++ b/source/regexp/vss-regular_expressions.ads
@@ -174,4 +174,7 @@ private
    overriding procedure Adjust (Self : in out Regular_Expression_Match);
    overriding procedure Finalize (Self : in out Regular_Expression_Match);
 
+   type Simple_Assertion_Kind is
+     (Start_Of_Line, End_Of_Line, Word_Boundary, No_Word_Boundary);
+
 end VSS.Regular_Expressions;

--- a/testsuite/regexp/test_regexp_re_tests.adb
+++ b/testsuite/regexp/test_regexp_re_tests.adb
@@ -6,8 +6,6 @@
 
 with Ada.Command_Line;
 with Ada.Characters.Wide_Wide_Latin_1;
-with Ada.Strings.Wide_Wide_Fixed;
-with Ada.Strings.Wide_Wide_Maps;
 with Ada.Wide_Wide_Text_IO;
 
 with VSS.Application;
@@ -54,8 +52,8 @@ procedure Test_RegExp_RE_Tests is
      return VSS.Strings.Virtual_String;
    --  Interprete `\x{AA}`
 
-   Space : constant Ada.Strings.Wide_Wide_Maps.Wide_Wide_Character_Set :=
-     Ada.Strings.Wide_Wide_Maps.To_Set
+   Tab : constant VSS.Characters.Virtual_Character :=
+     VSS.Characters.Virtual_Character
        (Ada.Characters.Wide_Wide_Latin_1.HT);
 
    -------------------
@@ -115,7 +113,7 @@ procedure Test_RegExp_RE_Tests is
      return VSS.Strings.Virtual_String
    is
       Img : constant Wide_Wide_String :=
-        VSS.Strings.Character_Count'Wide_Wide_Image (Value);
+        VSS.Strings.Character_Count'Base'Wide_Wide_Image (Value);
    begin
       return VSS.Strings.To_Virtual_String (Img (2 .. Img'Last));
    end Image;
@@ -130,8 +128,8 @@ procedure Test_RegExp_RE_Tests is
       Sample  : out VSS.Strings.Virtual_String;
       Check   : out Check_Value)
    is
-      From : array (1 .. 5) of Positive;
-      To   : array (0 .. 5) of Natural := (others => 0);
+      List : constant VSS.String_Vectors.Virtual_String_Vector :=
+        VSS.Strings.To_Virtual_String (Line).Split (Tab);
    begin
       --  Parse 5 columns
       --  1 => pattern
@@ -139,40 +137,40 @@ procedure Test_RegExp_RE_Tests is
       --  3 => has match
       --  4 => expression to evaluate
       --  5 => evaluated value
-      for J in From'Range loop
-         Ada.Strings.Wide_Wide_Fixed.Find_Token
-           (Source => Line,
-            Set    => Space,
-            From   => To (J - 1) + 1,
-            Test   => Ada.Strings.Outside,
-            First  => From (J),
-            Last   => To (J));
-      end loop;
 
-      if Line (From (1)) /= '/' then
-         Pattern := VSS.Strings.To_Virtual_String (Line (From (1) .. To (1)));
-      elsif Line (To (1)) = '/' then  --  Pattern is `/regexp/`
-         Pattern := VSS.Strings.To_Virtual_String
-              (Line (From (1) + 1 .. To (1) - 1));
+      if not List (1).Starts_With ("/") then
+         Pattern := List (1);
+      elsif List (1).Ends_With ("/") then  --  Pattern is `/regexp/`
+         Pattern := List (1);
+
+         declare
+            From : VSS.Strings.Character_Iterators.Character_Iterator :=
+              Pattern.At_First_Character;
+            To : VSS.Strings.Character_Iterators.Character_Iterator :=
+              Pattern.At_Last_Character;
+         begin
+            if From.Forward and To.Backward then
+               Pattern := Pattern.Slice (From, To);
+            else
+               raise Program_Error;
+            end if;
+         end;
       else  --  Pattern in form of `/regexp/FLAGS` isn't supported yet
          Check := (Kind => Skip);
          return;
       end if;
 
-      Sample := VSS.Strings.To_Virtual_String (Line (From (2) .. To (2)));
+      Sample := List (2);
       Sample := Expand_Sample (Sample);
 
       declare
-         Status : constant Wide_Wide_String := Line (From (3) .. To (3));
-         Expr   : constant Wide_Wide_String := Line (From (4) .. To (4));
-         Expect : constant Wide_Wide_String := Line (From (5) .. To (5));
+         Status : constant VSS.Strings.Virtual_String := List (3);
+         Expr   : constant VSS.Strings.Virtual_String := List (4);
+         Expect : constant VSS.Strings.Virtual_String := List (5);
       begin
-         case Status (Status'First) is
+         case Status.At_First_Character.Element is
             when 'y' =>
-               Check := (Match,
-                         VSS.Strings.To_Virtual_String (Expr),
-                         Expand_Sample
-                           (VSS.Strings.To_Virtual_String (Expect)));
+               Check := (Match, Expr, Expand_Sample (Expect));
             when 'n' =>
                Check := (Kind => Dont_Match);
             when others =>   --  'c'  --  compile error
@@ -254,7 +252,9 @@ procedure Test_RegExp_RE_Tests is
                           VSS.Strings.Cursors.Markers.Character_Marker :=
                             Match.First_Marker (Index);
                      begin
-                        Result.Append (Image (Marker.Character_Index - 1));
+                        if Marker.Is_Valid then
+                           Result.Append (Image (Marker.Character_Index - 1));
+                        end if;
                      end;
 
                      pragma Assert (Cursor.Element = ']');
@@ -272,7 +272,9 @@ procedure Test_RegExp_RE_Tests is
                           VSS.Strings.Cursors.Markers.Character_Marker :=
                             Match.Last_Marker (Index);
                      begin
-                        Result.Append (Image (Marker.Character_Index));
+                        if Marker.Is_Valid then
+                           Result.Append (Image (Marker.Character_Index));
+                        end if;
                      end;
 
                      pragma Assert (Cursor.Element = ']');
@@ -345,7 +347,7 @@ begin
                      Last_Pattern :=
                        VSS.Regular_Expressions.To_Regular_Expression (Pattern);
 
-                     Last_Sample := VSS.Strings.Empty_Virtual_String;
+                     Last_Sample := "not-a-sample";
                   end if;
 
                   if Last_Sample /= Sample then


### PR DESCRIPTION
Move iteration over sample character into `Loop_Over_Characters`
routine. Rewrite `test_regexp_re_tests.adb` line parser from
`Find_Token` to Virtual_String_List to be able to process empty
samples and change never-matching sample value from an empty
string to `"not-a-sample"`.

Add README.md with list of supported features.

V615-026