### PR TITLE
UC16-011 RegExp: Allow char escapes in a char class

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ GPRINSTALL_FLAGS = --prefix=$(PREFIX) --exec-subdir=$(INSTALL_EXEC_DIR)\
  --lib-subdir=$(INSTALL_ALI_DIR) --project-subdir=$(INSTALL_PROJECT_DIR)\
  --link-lib-subdir=$(INSTALL_LIBRARY_DIR) --sources-subdir=$(INSTALL_INCLUDE_DIR)
 
-OK_RE_TESTS := 501 # Number of re_tests to be passed
+OK_RE_TESTS := 504 # Number of re_tests to be passed
 
 ifeq ($(OS),Windows_NT)
 	VSS_PS=;

--- a/source/regexp/README.md
+++ b/source/regexp/README.md
@@ -22,13 +22,14 @@ For now we have:
 | **[** *x* **-** *y* **]** | Character in range *x..y*                 |
 | **[\p{** *N* **}]**       | Char of the general category *N*          |
 | **[\P{** *N* **}]**       | Char not of the general category *N*      |
-|  **^**                    | Start of line assertion                   |
-|  **$**                    | End of line assertion                     |
-|  **\b**                   | Word boundary assertion                   |
-|  **\B**                   | Not a word boundary assertion             |
-|  *x*                      | Character literal *x*, not in `^$.*+?]{}` |
-|  **\\** *x*               | Character literal *x* in `^$.*+?]{}`      |
-|  **\\n** **\\r** **\\t**  | New line, tabulation and other controls   |
+| **^**                     | Start of line assertion                   |
+| **$**                     | End of line assertion                     |
+| **\b**                    | Word boundary assertion                   |
+| **\B**                    | Not a word boundary assertion             |
+| *x*                       | Character literal *x*, not in `^$.*+?]{}` |
+| **\\** *x*                | Character literal *x* in `^$.*+?]{}`      |
+| **\\n** **\\r** **\\t**   | New line, tabulation and other controls   |
+| **[\\n\\r]**              | The same in a character class             |
 
 ## Useful articles
 

--- a/source/regexp/implementation/vss-regular_expressions-ecma_parser.adb
+++ b/source/regexp/implementation/vss-regular_expressions-ecma_parser.adb
@@ -98,7 +98,8 @@ package body VSS.Regular_Expressions.ECMA_Parser is
 
       procedure Class_Escape
         (Value : out Character_Or_Set;
-         Ok    : in out Boolean);
+         Ok    : in out Boolean)
+          with Pre => Ok;
 
       procedure Character_Class_Escape
         (Value : out Name_Sets.General_Category_Set; Ok : in out Boolean);
@@ -397,15 +398,28 @@ package body VSS.Regular_Expressions.ECMA_Parser is
 
       procedure Class_Escape
         (Value : out Character_Or_Set;
-         Ok    : in out Boolean)
-      is
-         Set : Name_Sets.General_Category_Set;
+         Ok    : in out Boolean) is
       begin
-         Character_Class_Escape (Set, Ok);
-
-         if Ok then
-            Value := (Is_Character => False, Category => Set);
+         if not Cursor.Has_Element then
+            Ok := False;
+            Error := "Unexpected end of string";
+            return;
          end if;
+
+         case Cursor.Element is
+            when 'p' | 'P' =>
+               Value := (Is_Character => False, Category => <>);
+               Character_Class_Escape (Value.Category, Ok);
+
+            when '-' =>
+               Expect ('-', Ok);
+               Value := (Is_Character => True, Character => '-');
+
+            when others =>
+               Value := (Is_Character => True, Character => <>);
+               Character_Escape (Value.Character, Ok);
+         end case;
+
       end Class_Escape;
 
       procedure Class_Ranges

--- a/testsuite/regexp/test_regexp_re_tests.adb
+++ b/testsuite/regexp/test_regexp_re_tests.adb
@@ -10,6 +10,7 @@ with Ada.Wide_Wide_Text_IO;
 
 with VSS.Application;
 with VSS.Characters;
+with VSS.Characters.Latin;
 with VSS.Regular_Expressions;
 with VSS.Strings;
 with VSS.Strings.Cursors.Markers;
@@ -50,7 +51,7 @@ procedure Test_RegExp_RE_Tests is
 
    function Expand_Sample (Value : VSS.Strings.Virtual_String)
      return VSS.Strings.Virtual_String;
-   --  Interprete `\x{AA}`
+   --  Interprete `\n`, `\x{AA}`
 
    Tab : constant VSS.Characters.Virtual_Character :=
      VSS.Characters.Virtual_Character
@@ -96,6 +97,8 @@ procedure Test_RegExp_RE_Tests is
                   end if;
                end if;
             end;
+         elsif List (J).Starts_With ("n") then
+            Result.Append (VSS.Characters.Latin.Line_Feed);
          else
             Result.Append ('\');
             Result.Append (List (J));


### PR DESCRIPTION
like `[\n\r]`.