### PR TITLE
Allow requiring a given number of positional options in the command line parser

### DIFF
--- a/source/os/implementation/vss-command_line-parsers.adb
+++ b/source/os/implementation/vss-command_line-parsers.adb
@@ -411,6 +411,13 @@ package body VSS.Command_Line.Parsers is
          Index := Index + 1;
       end loop;
 
+      if Natural (Self.Positional_Options_Values.Length)
+         < Self.Required_Positional_Options
+      then
+         Self.Error_Message := "missing required positional options";
+         Success            := False;
+      end if;
+
       return Success;
    end Parse;
 
@@ -713,6 +720,17 @@ package body VSS.Command_Line.Parsers is
 
       Item := Item.Tail_After (Iterator);
    end Remove_Prefix;
+
+   --------------------------------
+   -- Require_Positional_Options --
+   --------------------------------
+
+   procedure Require_Positional_Options
+      (Self  : in out Command_Line_Parser'Class;
+       Count : Natural) is
+   begin
+      Self.Required_Positional_Options := Count;
+   end Require_Positional_Options;
 
    ------------------------------
    -- Unknown_Option_Arguments --

--- a/source/os/implementation/vss-command_line.adb
+++ b/source/os/implementation/vss-command_line.adb
@@ -184,6 +184,15 @@ package body VSS.Command_Line is
       GNAT.OS_Lib.OS_Exit (0);
    end Report_Message;
 
+   --------------------------------
+   -- Require_Positional_Options --
+   --------------------------------
+
+   procedure Require_Positional_Options (Count : Natural) is
+   begin
+      Parser.Require_Positional_Options (Count);
+   end Require_Positional_Options;
+
    -----------------
    -- Unique_Name --
    -----------------

--- a/source/os/vss-command_line-parsers.ads
+++ b/source/os/vss-command_line-parsers.ads
@@ -24,6 +24,11 @@ package VSS.Command_Line.Parsers is
       Option : Abstract_Option'Class);
    --  Add command line option.
 
+   procedure Require_Positional_Options
+      (Self  : in out Command_Line_Parser'Class;
+       Count : Natural);
+   --   Make the parser fail if any positional options aren't provided.
+
    function Parse
      (Self      : in out Command_Line_Parser'Class;
       Arguments : VSS.String_Vectors.Virtual_String_Vector) return Boolean;
@@ -129,6 +134,8 @@ private
       Defined_Positional_Options   : Positional_Option_Vectors.Vector;
       Defined_Multivalue_Positional_Option :
         Multivalue_Positional_Option_Holders.Holder;
+
+      Required_Positional_Options : Natural := 0;
 
       Error_Message                : VSS.Strings.Virtual_String;
       Only_Positional              : Boolean := False;

--- a/source/os/vss-command_line-parsers.ads
+++ b/source/os/vss-command_line-parsers.ads
@@ -43,7 +43,7 @@ package VSS.Command_Line.Parsers is
    function Is_Specified
      (Self   : Command_Line_Parser'Class;
       Option : Abstract_Option'Class) return Boolean;
-   --  Return True when given option has been specified the command line.
+   --  Return True when given option has been specified on the command line.
 
    function Value
      (Self   : Command_Line_Parser'Class;

--- a/source/os/vss-command_line.ads
+++ b/source/os/vss-command_line.ads
@@ -51,6 +51,9 @@ package VSS.Command_Line is
 
    procedure Add_Option (Option : Abstract_Option'Class);
 
+   procedure Require_Positional_Options (Count : Natural);
+   --   Make the parser fail if any positional options aren't provided.
+
    procedure Add_Help_Option;
    --  Adds builtin definition of the option to display help information. This
    --  option is handled automatically.


### PR DESCRIPTION
I've been slowly writing a static site generator in Ada using VSS, and being able to require that some positional arguments are provided would be fairly useful for me. Of course this can be done with `Is_Specified`, but, given that this is a small change here, I thought it might make sense upstream. Please let me know what you think and if there are any changes you'd like to see.

Thanks!